### PR TITLE
feat: delete session state file when session is deleted

### DIFF
--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -36,7 +36,13 @@ import {
 } from "./commands"
 import { type HostPermissionSnapshot } from "./host-permissions"
 import { compressPermission, syncCompressPermissionState } from "./compress-permission"
-import { checkSession, ensureSessionInitialized, saveSessionState, syncToolCache } from "./state"
+import {
+    checkSession,
+    deleteSessionState,
+    ensureSessionInitialized,
+    saveSessionState,
+    syncToolCache,
+} from "./state"
 import { cacheSystemPromptTokens } from "./ui/utils"
 
 const INTERNAL_AGENT_SIGNATURES = [
@@ -292,6 +298,14 @@ export function createEventHandler(state: SessionState, logger: Logger) {
                     Number.isFinite(input.event.properties.time)
                   ? input.event.properties.time
                   : undefined
+
+        if (input.event.type === "session.deleted") {
+            const sessionId = input.event.properties.info?.id
+            if (sessionId) {
+                await deleteSessionState(sessionId).catch(() => {})
+            }
+            return
+        }
 
         if (input.event.type !== "message.part.updated") {
             return

--- a/lib/state/persistence.ts
+++ b/lib/state/persistence.ts
@@ -203,6 +203,11 @@ export async function loadSessionState(
     }
 }
 
+export async function deleteSessionState(sessionId: string): Promise<void> {
+    const filePath = getSessionFilePath(sessionId)
+    await fs.unlink(filePath)
+}
+
 export interface AggregatedStats {
     totalTokens: number
     totalTools: number


### PR DESCRIPTION
DCP persists pruned tool state per session at `~/.local/share/opencode/storage/plugin/dcp/{sessionId}.json`. When a session is deleted, the corresponding state file remains on disk as an orphan and accumulates over time.
The opencode SDK already emits a `session.deleted` event with the session ID. This PR adds a handler in `createEventHandler` that calls `fs.unlink` to remove the state file when a session is deleted.
Changes:
- `lib/state/persistence.ts`: export `deleteSessionState(sessionId)` — deletes the session state file
- `lib/hooks.ts`: handle `session.deleted` event in the event handler, calling `deleteSessionState`