### PR TITLE
fix: add tiktoken as a direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
                 "@opentui/core": "^0.2.16",
                 "@opentui/solid": "^0.2.16",
                 "jsonc-parser": "^3.3.1",
-                "solid-js": "^1.9.12"
+                "solid-js": "^1.9.12",
+                "tiktoken": "^1.0.10"
             },
             "devDependencies": {
                 "@opencode-ai/plugin": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
         "@opentui/core": "^0.2.16",
         "@opentui/solid": "^0.2.16",
         "jsonc-parser": "^3.3.1",
-        "solid-js": "^1.9.12"
+        "solid-js": "^1.9.12",
+        "tiktoken": "^1.0.10"
     },
     "devDependencies": {
         "@opencode-ai/plugin": "^1.4.3",


### PR DESCRIPTION
## Problem

On a fresh install (`3.1.13`), the plugin **silently fails to load**: no `/dcp` or `/dcp-compress` commands, no compress tool, no prune notifications, and no debug logs are written even with `"debug": true`.

## Root cause

`@anthropic-ai/tokenizer` does `require("tiktoken/lite")`, but `tiktoken` is only a **transitive** dependency. opencode's plugin installer does not always install it into the plugin cache (`~/.cache/opencode/packages/@tarquinen/opencode-dcp@latest/node_modules`), so importing the plugin entry throws:

```
Cannot find module 'tiktoken/lite' from '...@anthropic-ai/tokenizer/dist/cjs/index.js'
```

opencode catches this and silently drops the whole plugin, so nothing is surfaced to the user.

## Fix

Promote `tiktoken` to a **direct** dependency. Direct dependencies are installed reliably by opencode's installer; the one that went missing here was a child of `@anthropic-ai/tokenizer`. `tiktoken` was already present in `package-lock.json` as a transitive dep (`1.0.22`), so this only adds the top-level declaration — no version change, no new resolution.

## Verification

Reproduced the broken import, applied the equivalent of this change to the installed cache, then re-imported:

```
bun -e "await import('.../dist/index.js')"  # before: IMPORT ERROR: Cannot find module 'tiktoken/lite'
                                            # after:  OK
```

After the fix, restarting opencode exposes `/dcp` + `/dcp-compress` and DCP debug logs are written as expected.

Closes #575
