### PR TITLE
fix: register /dcp command with OpenCode

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,6 +16,7 @@ import {
     createSystemPromptHandler,
     createTextCompleteHandler,
 } from "./lib/hooks"
+import { registerOpencodeCommands } from "./lib/commands/register"
 import { configureClientAuth, isSecureMode } from "./lib/auth"
 import { startAutoUpdate } from "./lib/update"
 
@@ -94,13 +95,7 @@ const server: Plugin = (async (ctx) => {
                 config.compress.permission = "deny"
             }
 
-            if (config.commands.enabled && config.compress.permission !== "deny") {
-                opencodeConfig.command ??= {}
-                opencodeConfig.command["dcp-compress"] = {
-                    template: "",
-                    description: "Trigger DCP manual compression with: /dcp-compress [focus]",
-                }
-            }
+            registerOpencodeCommands(opencodeConfig, config)
 
             const toolsToAdd: string[] = []
             if (config.compress.permission !== "deny" && !config.experimental.allowSubAgents) {

--- a/lib/commands/register.ts
+++ b/lib/commands/register.ts
@@ -1,0 +1,30 @@
+import type { PluginConfig } from "./config"
+
+type OpencodeCommandConfig = {
+    template: string
+    description: string
+}
+
+type OpencodeConfig = {
+    command?: Record<string, OpencodeCommandConfig>
+}
+
+export function registerOpencodeCommands(
+    opencodeConfig: OpencodeConfig,
+    config: PluginConfig,
+): void {
+    if (!config.commands.enabled || config.compress.permission === "deny") {
+        return
+    }
+
+    opencodeConfig.command ??= {}
+    opencodeConfig.command["dcp"] = {
+        template: "",
+        description:
+            "DCP context management: /dcp stats, /dcp context, /dcp sweep, /dcp manual, /dcp decompress, /dcp recompress",
+    }
+    opencodeConfig.command["dcp-compress"] = {
+        template: "",
+        description: "Trigger DCP manual compression with: /dcp-compress [focus]",
+    }
+}

--- a/tests/plugin-commands.test.ts
+++ b/tests/plugin-commands.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import type { PluginConfig } from "../lib/config"
+import { registerOpencodeCommands } from "../lib/commands/register"
+
+function buildConfig(permission: "allow" | "deny" = "allow"): PluginConfig {
+    return {
+        enabled: true,
+        debug: false,
+        pruneNotification: "off",
+        pruneNotificationType: "chat",
+        commands: { enabled: true, protectedTools: [] },
+        manualMode: { enabled: false, automaticStrategies: true },
+        turnProtection: { enabled: false, turns: 4 },
+        experimental: { allowSubAgents: false, customPrompts: false },
+        protectedFilePatterns: [],
+        compress: {
+            mode: "message",
+            permission,
+            showCompression: false,
+            maxContextLimit: 150000,
+            minContextLimit: 50000,
+            nudgeFrequency: 5,
+            iterationNudgeThreshold: 15,
+            nudgeForce: "soft",
+            protectedTools: ["task"],
+            protectTags: false,
+            protectUserMessages: false,
+        },
+        strategies: {
+            deduplication: { enabled: true, protectedTools: [] },
+            purgeErrors: { enabled: true, turns: 4, protectedTools: [] },
+        },
+    } as PluginConfig
+}
+
+test("registerOpencodeCommands exposes /dcp and /dcp-compress", () => {
+    const opencodeConfig: Record<string, unknown> = {}
+    registerOpencodeCommands(opencodeConfig, buildConfig("allow"))
+
+    const commands = opencodeConfig.command as Record<string, { description: string }>
+    assert.ok(commands.dcp)
+    assert.match(commands.dcp.description, /\/dcp manual/)
+    assert.ok(commands["dcp-compress"])
+})
+
+test("registerOpencodeCommands skips commands when compress is denied", () => {
+    const opencodeConfig: Record<string, unknown> = {}
+    registerOpencodeCommands(opencodeConfig, buildConfig("deny"))
+
+    assert.equal(opencodeConfig.command, undefined)
+})


### PR DESCRIPTION
## Summary
- Register the `/dcp` command in plugin config alongside `/dcp-compress`.
- Extract command registration into `registerOpencodeCommands()` for focused tests.

Fixes #588

## Test plan
- [x] `npm test -- tests/plugin-commands.test.ts`
- [x] `npm test`