### PR TITLE
Add chat.message fallback for /dcp-compress when host skips command registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,20 @@ DCP provides a TUI panel and one prompt-producing slash command:
 - `/dcp` — Opens the DCP panel with context, stats, and manual-mode controls.
 - `/dcp-compress [focus]` — Asks the model to run one compression pass. Optional focus text directs what content to compress, following the active `compress.mode`.
 
+> [!NOTE]
+> On some OpenCode versions the slash-command list is snapshotted before plugin `config` hooks run, so `/dcp-compress` may not appear in the autocomplete list even though DCP loaded correctly. Typing `/dcp-compress [focus]` as a plain message still works — DCP intercepts it via its `chat.message` hook and triggers compression identically. To also restore autocomplete, declare the command in `opencode.json`:
+>
+> ```jsonc
+> {
+>   "command": {
+>     "dcp-compress": {
+>       "template": "",
+>       "description": "Trigger DCP manual compression with: /dcp-compress [focus]"
+>     }
+>   }
+> }
+> ```
+
 ### Prompt Overrides
 
 DCP exposes six editable prompts:

--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,7 @@ import { Logger } from "./lib/logger"
 import { createSessionState } from "./lib/state"
 import { PromptStore } from "./lib/prompts/store"
 import {
+    createChatMessageHandler,
     createChatMessageTransformHandler,
     createCommandExecuteHandler,
     createEventHandler,
@@ -75,6 +76,13 @@ const server: Plugin = (async (ctx) => {
             logger,
             config,
             ctx.directory,
+            hostPermissions,
+        ),
+        "chat.message": createChatMessageHandler(
+            ctx.client,
+            state,
+            logger,
+            config,
             hostPermissions,
         ),
         event: createEventHandler(state, logger),

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -289,6 +289,99 @@ export function createCommandExecuteHandler(
     }
 }
 
+export function createChatMessageHandler(
+    client: any,
+    state: SessionState,
+    logger: Logger,
+    config: PluginConfig,
+    hostPermissions: HostPermissionSnapshot,
+) {
+    return async (
+        input: { sessionID: string },
+        output: { parts: any[] },
+    ) => {
+        if (!config.commands.enabled) {
+            return
+        }
+
+        // Fallback for hosts that never registered the dcp-compress command
+        // (e.g. OpenCode builds its slash-command snapshot before plugin
+        // config hooks run). A plain-text "/dcp-compress [focus]" message is
+        // intercepted here and routed through the same manual-trigger path as
+        // the slash command.
+        const textPart = output.parts.find(
+            (part) =>
+                part?.type === "text" &&
+                typeof part.text === "string" &&
+                !part.ignored &&
+                !part.synthetic,
+        )
+        if (!textPart) {
+            return
+        }
+
+        const trimmed = textPart.text.trim()
+        if (!trimmed.startsWith("/dcp-compress")) {
+            return
+        }
+
+        // The slash-command path already set a pending trigger for this turn;
+        // don't double-process it.
+        if (state.pendingManualTrigger) {
+            return
+        }
+
+        const messagesResponse = await client.session.messages({
+            path: { id: input.sessionID },
+        })
+        const messages = filterMessages(messagesResponse.data || messagesResponse)
+
+        await ensureSessionInitialized(
+            client,
+            state,
+            input.sessionID,
+            logger,
+            messages,
+            config.manualMode.enabled,
+        )
+
+        syncCompressPermissionState(state, config, hostPermissions, messages)
+
+        if (compressPermission(state, config) === "deny") {
+            return
+        }
+
+        const focus = trimmed.slice("/dcp-compress".length).trim()
+        const prompt = await handleManualTriggerCommand(
+            {
+                client,
+                state,
+                config,
+                logger,
+                sessionId: input.sessionID,
+                messages,
+            },
+            "compress",
+            focus,
+        )
+        if (!prompt) {
+            return
+        }
+
+        state.manualMode = "compress-pending"
+        state.pendingManualTrigger = {
+            sessionId: input.sessionID,
+            prompt,
+        }
+        // Normalize the stored message to the canonical marker so downstream
+        // pruning/summary logic sees exactly what the slash-command path emits.
+        textPart.text = focus ? `/dcp-compress ${focus}` : "/dcp-compress"
+        logger.info("Intercepted plain-text /dcp-compress message", {
+            sessionId: input.sessionID,
+        })
+    }
+}
+
 export function createTextCompleteHandler() {
     return async (
         _input: { sessionID: string; messageID: string; partID: string },


### PR DESCRIPTION
Fixes #609

## Problem

On recent OpenCode versions (post Effect-refactor), the slash-command list is built as a one-shot snapshot in `packages/opencode/src/command/index.ts` before plugin `config` hooks run. DCP registers `/dcp-compress` inside its `config` hook, so the registration lands after the snapshot was taken and never gets picked up: the command is missing from autocomplete and typing it manually just sends a plain user message.

## Fix

Add a `"chat.message"` hook as a fallback path:

- When a user message's first non-ignored/non-synthetic text part starts with `/dcp-compress`, run the same manual-trigger flow as the slash command (`handleManualTriggerCommand` -> `state.manualMode = "compress-pending"` -> `state.pendingManualTrigger`), which the existing `applyPendingManualTrigger` consumes on the next messages transform.
- Normalize the stored text to the canonical `/dcp-compress [focus]` marker so downstream pruning/summary logic sees exactly what the slash-command path emits.
- Skip when `state.pendingManualTrigger` already exists (the real slash-command path ran and set it), when `commands.enabled` is false, or when compress permission resolves to `deny`.

This makes `/dcp-compress` work even when the host never registered the command, with zero behavior change on hosts where registration works normally.

## Verification

- `npm run build` passes (tsup + tsc).
- Full test suite: 103/103 pass.
- Behavioral check against the built bundle:
  - plain messages are untouched;
  - `/dcp-compress <focus>` fetches session state, sets the pending trigger, and normalizes the marker;
  - a second invocation while a trigger is pending is skipped;
  - `ignored`/`synthetic` parts are not intercepted.
- README documents the snapshot-timing caveat and the `opencode.json` workaround for restoring autocomplete.
